### PR TITLE
Update makefixed.js

### DIFF
--- a/makefixed.js
+++ b/makefixed.js
@@ -96,7 +96,7 @@ $.fn.makeFixed = function (options)
 
 			/* Set element as fixed */
 
-			if (el.attr(attr.fAtPos) <= scrolled)
+			if (el.attr(attr.fAtPos) <= scrolled && scrolled > 0)
 			{
 
 				el.attr(attr.cIsFixed, 1);


### PR DESCRIPTION
I added this otherwise control in my case when the fixture was originally the first, scrolling down everything worked, but returning to the original position was not airing the original div.